### PR TITLE
Add home gallery and featured product showcase

### DIFF
--- a/index.html
+++ b/index.html
@@ -54,6 +54,33 @@
       </div>
     </section>
 
+    <section class="photo-gallery" aria-labelledby="gallery-title">
+      <div class="container">
+        <div class="section-heading">
+          <h2 id="gallery-title">Moments from Our Bakery</h2>
+          <p>Glowing lanterns, freshly baked mooncakes, and festive gift sets that celebrate every Mid-Autumn gathering.</p>
+        </div>
+        <div class="gallery-grid">
+          <figure class="gallery-card">
+            <img src="home%20images/banh-kinh-do-1142696503.jpg" alt="Decorative tins of Kinh Do mooncakes arranged beside tea." />
+            <figcaption>Seasonal mooncake tins ready to delight families and friends.</figcaption>
+          </figure>
+          <figure class="gallery-card">
+            <img src="home%20images/Mua-banh-trung-thu-Kinh-Do-o-dau-Bang-gia-3704805917.jpg" alt="Display of assorted Kinh Do mooncakes in bright red packaging." />
+            <figcaption>Bold red packaging that captures the spirit of Mid-Autumn festivals.</figcaption>
+          </figure>
+          <figure class="gallery-card">
+            <img src="home%20images/2384-1-1606988458230392212630-3099024397.jpg" alt="A close-up of mooncakes with golden crusts and patterned tops." />
+            <figcaption>Handcrafted crusts stamped with heritage motifs and golden shine.</figcaption>
+          </figure>
+          <figure class="gallery-card">
+            <img src="home%20images/banh-kinh-do-1373247095.png" alt="Gift box with mooncakes, teacups, and lantern decorations." />
+            <figcaption>Curated gift boxes pairing mooncakes with tea for heartfelt gifting.</figcaption>
+          </figure>
+        </div>
+      </div>
+    </section>
+
     <section id="story">
       <div class="container our-story">
         <div class="section-heading">

--- a/products.html
+++ b/products.html
@@ -92,6 +92,47 @@
       </div>
     </section>
 
+    <section class="featured-products" aria-labelledby="featured-products">
+      <div class="container">
+        <div class="section-heading">
+          <h2 id="featured-products">Featured Products</h2>
+          <p>Limited seasonal releases that highlight the craftsmanship and flavours at the heart of Kinh Do mooncakes.</p>
+        </div>
+        <div class="product-grid">
+          <article class="product-card">
+            <figure>
+              <img src="products/8934680042567-tet-1.jpg-236424703.png" alt="Deluxe Kinh Do mooncake gift set with vibrant red packaging." />
+            </figure>
+            <div class="product-info">
+              <div>
+                <h3>Heritage Lantern Collection</h3>
+                <p>A keepsake hamper with four signature baked mooncakes, jasmine tea pairing, and a silk lantern-inspired box.</p>
+              </div>
+              <div class="product-meta">
+                <span class="price">₫850,000</span>
+                <a class="btn btn-primary" href="contact.html">Reserve Now</a>
+              </div>
+            </div>
+          </article>
+          <article class="product-card">
+            <figure>
+              <img src="products/banh-trung-thu-kinh-do-deo-dau-xanh-hat-dua-0-trung-230gr-3901982844.jpg" alt="Green bean and melon seed mochi-style mooncake from Kinh Do." />
+            </figure>
+            <div class="product-info">
+              <div>
+                <h3>Soft Green Bean Mochi Cake</h3>
+                <p>Chewy snow-skin mooncake filled with pandan green bean paste and crunchy melon seeds for a modern twist.</p>
+              </div>
+              <div class="product-meta">
+                <span class="price">₫120,000</span>
+                <a class="btn btn-primary" href="contact.html">Add to Order</a>
+              </div>
+            </div>
+          </article>
+        </div>
+      </div>
+    </section>
+
     <section id="mooncakes">
       <div class="container">
         <div class="spotlight">

--- a/styles.css
+++ b/styles.css
@@ -300,7 +300,7 @@
       gap: 1.75rem;
     }
 
-    .card {
+    .card { 
       background: rgba(255, 255, 255, 0.85);
       border-radius: var(--rounded-medium);
       padding: 2rem;
@@ -320,6 +320,45 @@
     .card p {
       margin: 0;
       color: var(--text-muted);
+    }
+
+    .photo-gallery .container {
+      background: rgba(255, 255, 255, 0.82);
+      border-radius: var(--rounded-large);
+      padding: clamp(2.5rem, 5vw, 4rem);
+      box-shadow: var(--shadow-soft);
+      display: grid;
+      gap: clamp(2rem, 5vw, 3rem);
+    }
+
+    .gallery-grid {
+      display: grid;
+      gap: 1.5rem;
+      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    }
+
+    .gallery-card {
+      background: rgba(255, 255, 255, 0.85);
+      border-radius: var(--rounded-medium);
+      padding: 1.2rem;
+      border: 1px solid rgba(215, 31, 38, 0.08);
+      box-shadow: var(--shadow-soft);
+      display: grid;
+      gap: 0.85rem;
+    }
+
+    .gallery-card img {
+      width: 100%;
+      height: clamp(180px, 30vw, 260px);
+      object-fit: cover;
+      border-radius: 18px;
+    }
+
+    .gallery-card figcaption {
+      margin: 0;
+      color: var(--text-muted);
+      font-size: 0.95rem;
+      line-height: 1.6;
     }
 
     .tags {
@@ -392,6 +431,69 @@
       background: rgba(215, 31, 38, 0.12);
       color: var(--brand-primary);
       font-weight: 600;
+    }
+
+    .featured-products .container {
+      display: grid;
+      gap: clamp(2rem, 5vw, 3.5rem);
+    }
+
+    .product-grid {
+      display: grid;
+      gap: 1.75rem;
+    }
+
+    .product-card {
+      background: rgba(255, 255, 255, 0.9);
+      border-radius: var(--rounded-medium);
+      border: 1px solid rgba(215, 31, 38, 0.08);
+      box-shadow: var(--shadow-soft);
+      overflow: hidden;
+      display: grid;
+    }
+
+    .product-card figure {
+      margin: 0;
+      overflow: hidden;
+    }
+
+    .product-card img {
+      width: 100%;
+      height: clamp(220px, 32vw, 300px);
+      object-fit: cover;
+      display: block;
+    }
+
+    .product-info {
+      padding: clamp(1.5rem, 3vw, 2.25rem);
+      display: grid;
+      gap: 1.5rem;
+    }
+
+    .product-info h3 {
+      margin: 0 0 0.75rem;
+      font-family: 'Playfair Display', serif;
+      font-size: clamp(1.4rem, 3vw, 1.8rem);
+      color: var(--brand-dark);
+    }
+
+    .product-info p {
+      margin: 0;
+      color: var(--text-muted);
+    }
+
+    .product-meta {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 1rem;
+      flex-wrap: wrap;
+    }
+
+    .price {
+      font-weight: 600;
+      font-size: 1.1rem;
+      color: var(--brand-primary);
     }
 
     .our-story {
@@ -635,6 +737,14 @@
       .heritage-grid {
         grid-template-columns: 1fr 1fr;
       }
+
+      .gallery-grid {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+      }
+
+      .product-grid {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+      }
     }
 
     @media (min-width: 1024px) {
@@ -652,5 +762,13 @@
 
       .hero-stats {
         align-self: end;
+      }
+
+      .gallery-grid {
+        grid-template-columns: repeat(4, minmax(0, 1fr));
+      }
+
+      .product-grid {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
       }
     }


### PR DESCRIPTION
## Summary
- add a photo gallery section on the home page to showcase bakery imagery
- introduce a featured products section with two highlighted items and imagery
- extend styles to support the new gallery and product card layouts

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68c9a5279e048322a14034dc3a7b202e