### PR TITLE
Show full mooncake imagery without cropping

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -349,8 +349,7 @@
 
     .gallery-card img {
       width: 100%;
-      height: clamp(180px, 30vw, 260px);
-      object-fit: cover;
+      height: auto;
       border-radius: 18px;
     }
 
@@ -459,8 +458,7 @@
 
     .product-card img {
       width: 100%;
-      height: clamp(220px, 32vw, 300px);
-      object-fit: cover;
+      height: auto;
       display: block;
     }
 


### PR DESCRIPTION
## Summary
- remove the fixed height and cover fit on the homepage gallery so each photo displays fully
- allow product card images to render at their natural dimensions instead of being cropped

## Testing
- not run (static content change)


------
https://chatgpt.com/codex/tasks/task_e_68c9a8718a348322beea6056919e14e7