### PR TITLE
Enlarge home page gallery images

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -365,7 +365,7 @@
     .gallery-card img {
       width: 100%;
       border-radius: 18px;
-      aspect-ratio: 4 / 3;
+      aspect-ratio: 3 / 2;
       object-fit: cover;
     }
 
@@ -779,7 +779,7 @@
       }
 
       .gallery-grid {
-        grid-template-columns: repeat(3, minmax(0, 1fr));
+        grid-template-columns: repeat(2, minmax(0, 1fr));
       }
 
       .product-grid {


### PR DESCRIPTION
## Summary
- increase the home page gallery image aspect ratio so photos render taller
- limit the large-screen gallery layout to two columns to give each image more space

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68c9aec7f5888322abee35051b4497e0