### PR TITLE
Adjust gallery images for mobile

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -758,6 +758,19 @@
         padding: 3rem 0;
       }
 
+      .photo-gallery .container {
+        width: min(1120px, 96vw);
+        padding: 2rem;
+      }
+
+      .gallery-card {
+        padding: 1rem;
+      }
+
+      .gallery-card img {
+        aspect-ratio: 4 / 3;
+      }
+
       .header-actions {
         width: 100%;
         justify-content: center;


### PR DESCRIPTION
## Summary
- widen the Moments from Our Bakery container on narrow screens so gallery items can use more viewport width
- reduce gallery card padding and increase the image aspect ratio on mobile to present larger visuals

## Testing
- python -m http.server 8000

------
https://chatgpt.com/codex/tasks/task_e_68ca30dbaaec8322bf390029a8a15909