### PR TITLE
Enlarge bakery gallery images on mobile

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -759,8 +759,8 @@
       }
 
       .photo-gallery .container {
-        width: min(1120px, 96vw);
-        padding: 2rem;
+        width: min(1120px, 100vw);
+        padding: 2.25rem 1.5rem;
       }
 
       .gallery-card {
@@ -768,7 +768,8 @@
       }
 
       .gallery-card img {
-        aspect-ratio: 4 / 3;
+        aspect-ratio: 1 / 1;
+        border-radius: 22px;
       }
 
       .header-actions {


### PR DESCRIPTION
## Summary
- widen the bakery gallery container on small screens to use the full viewport width
- switch gallery imagery to a square aspect ratio with slightly larger rounding for a bolder mobile presentation

## Testing
- No automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68ca433479e48322b4ff3d3d1903fc7e