### PR TITLE
Enlarge gallery images on mobile

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -760,15 +760,15 @@
 
       .photo-gallery .container {
         width: min(1120px, 100vw);
-        padding: 2.25rem 1.5rem;
+        padding: 2.5rem 1rem;
       }
 
       .gallery-card {
-        padding: 1rem;
+        padding: 0.75rem;
       }
 
       .gallery-card img {
-        aspect-ratio: 1 / 1;
+        aspect-ratio: 4 / 5;
         border-radius: 22px;
       }
 


### PR DESCRIPTION
## Summary
- reduce padding around the gallery on small screens so photos fill more of the viewport
- increase the mobile gallery image aspect ratio to show taller crops for a larger appearance

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ca44a9a8bc832298a04a4d5ea8295c