### PR TITLE
Add Gen Z mooncake experience and generational toggles

### DIFF
--- a/index.html
+++ b/index.html
@@ -84,8 +84,20 @@
             />
           </figure>
           <span class="card-overline" data-i18n="heroCardOverline">Moonlit Signature</span>
-          <h2 data-i18n="heroCardTitle">Lotus Seed &amp; Golden Yolk</h2>
-          <p data-i18n="heroCardDescription">A harmonious blend of velvety lotus paste and salted egg yolk crafted for family traditions.</p>
+          <h2
+            data-i18n="heroCardTitle"
+            data-i18n-classic="heroCardTitle"
+            data-i18n-genz="heroCardTitleGenZ"
+          >
+            Lotus Seed &amp; Golden Yolk
+          </h2>
+          <p
+            data-i18n="heroCardDescription"
+            data-i18n-classic="heroCardDescription"
+            data-i18n-genz="heroCardDescriptionGenZ"
+          >
+            A harmonious blend of velvety lotus paste and salted egg yolk crafted for family traditions.
+          </p>
           <div class="hero-card-footer">
             <span data-i18n="heroCardFootnote1">Limited seasonal batch</span>
             <span data-i18n="heroCardFootnote2">Available now</span>
@@ -218,6 +230,9 @@
         heroCardTitle: 'Lotus Seed & Golden Yolk',
         heroCardDescription:
           'A harmonious blend of velvety lotus paste and salted egg yolk crafted for family traditions.',
+        heroCardTitleGenZ: 'Lava Mooncake with Aged Melting Eggs',
+        heroCardDescriptionGenZ:
+          'Custard lava mooncakes with slow-aged salted egg centres crafted for bold-night celebrations.',
         heroCardFootnote1: 'Limited seasonal batch',
         heroCardFootnote2: 'Available now',
         galleryHeading: 'Moments from Our Bakery',
@@ -279,6 +294,9 @@
         heroCardTitle: 'Hạt sen & trứng muối vàng',
         heroCardDescription:
           'Sự hòa quyện của nhân sen mịn màng và trứng muối đậm đà dành cho những buổi đoàn viên gia đình.',
+        heroCardTitleGenZ: 'Hộp Lava trứng chảy',
+        heroCardDescriptionGenZ:
+          'Phiên bản lava sánh mịn cùng trứng muối ủ lâu cho trải nghiệm tan chảy đậm đà.',
         heroCardFootnote1: 'Sản xuất theo mùa giới hạn',
         heroCardFootnote2: 'Đang mở bán',
         galleryHeading: 'Khoảnh khắc từ tiệm bánh của chúng tôi',
@@ -338,6 +356,9 @@
     const AGE_GATE_YEAR_START = 1945;
     const AGE_GATE_YEAR_END = 2025;
     const AGE_GATE_FILLER_COUNT = 2;
+    const GEN_Z_YEAR_THRESHOLD = 1997;
+    const GENERATION_CLASSIC = 'classic';
+    const GENERATION_GEN_Z = 'genZ';
 
     const translatableElements = document.querySelectorAll('[data-i18n]');
     const languageToggle = document.getElementById('language-toggle');
@@ -347,6 +368,86 @@
     const ageGateCloseButton = document.getElementById('age-gate-close');
     const ageGateConfirmButton = document.getElementById('age-gate-confirm');
     const ageGateFootnote = document.getElementById('age-gate-footnote');
+    const generationAwareElements = document.querySelectorAll('[data-i18n-classic], [data-i18n-genz]');
+    const heroCardImage = document.querySelector('.hero-card-media img');
+    const generationGroups = document.querySelectorAll('[data-generation-group]');
+    const heroCardMediaConfig = {
+      [GENERATION_CLASSIC]: {
+        src: 'vn-11134207-7r98o-lr866fv2vj5w60-3532510397.jpg',
+        alt: {
+          en: 'Lotus seed and salted egg yolk mooncake gift box with gilded accents.',
+          vi: 'Hộp bánh trung thu hạt sen và trứng muối vàng với họa tiết ánh kim.'
+        }
+      },
+      [GENERATION_GEN_Z]: {
+        src: 'Gen%20Z/lava-trung-chay-6-banh-2025.jpg',
+        alt: {
+          en: 'Lava mooncake gift box featuring aged molten salted egg fillings.',
+          vi: 'Hộp bánh lava trứng chảy với nhân trứng muối ủ lâu tan chảy.'
+        }
+      }
+    };
+
+    function parseBirthYear(value) {
+      const year = Number.parseInt(value, 10);
+      if (!Number.isInteger(year)) {
+        return null;
+      }
+      if (year < AGE_GATE_YEAR_START || year > AGE_GATE_YEAR_END) {
+        return null;
+      }
+      return year;
+    }
+
+    function determineGenerationFromBirthYear(year) {
+      if (Number.isInteger(year) && year > GEN_Z_YEAR_THRESHOLD) {
+        return GENERATION_GEN_Z;
+      }
+      return GENERATION_CLASSIC;
+    }
+
+    function applyGenerationMode() {
+      const isGenZ = currentGeneration === GENERATION_GEN_Z;
+
+      document.body.classList.toggle('generation-genz', isGenZ);
+      document.body.classList.toggle('generation-classic', !isGenZ);
+
+      generationAwareElements.forEach((element) => {
+        const targetKey = isGenZ ? element.dataset.i18nGenz : element.dataset.i18nClassic;
+        if (targetKey) {
+          element.dataset.i18n = targetKey;
+        }
+      });
+
+      if (heroCardImage) {
+        const config = heroCardMediaConfig[isGenZ ? GENERATION_GEN_Z : GENERATION_CLASSIC];
+        if (config?.src && heroCardImage.getAttribute('src') !== config.src) {
+          heroCardImage.setAttribute('src', config.src);
+        }
+        if (config?.alt) {
+          const altText = config.alt[currentLanguage] ?? config.alt.en;
+          if (altText) {
+            heroCardImage.setAttribute('alt', altText);
+          }
+        }
+      }
+
+      generationGroups.forEach((group) => {
+        const mode = group.dataset.generationGroup;
+        if (mode === GENERATION_GEN_Z) {
+          group.hidden = !isGenZ;
+        } else if (mode === GENERATION_CLASSIC) {
+          group.hidden = isGenZ;
+        }
+      });
+    }
+
+    function updateGenerationFromBirthYear(year) {
+      const parsedYear = typeof year === 'number' ? year : parseBirthYear(year);
+      currentGeneration = determineGenerationFromBirthYear(parsedYear);
+      applyGenerationMode();
+      applyTranslations(currentLanguage);
+    }
 
     let agePickerOptions = [];
     let agePickerOptionHeight = 0;
@@ -354,6 +455,9 @@
     let selectedBirthYear = null;
     let ageGateInitialized = false;
     let agePickerScrollTimeout;
+    let currentGeneration = determineGenerationFromBirthYear(
+      parseBirthYear(localStorage.getItem(AGE_GATE_BIRTH_YEAR_KEY))
+    );
 
     const LANGUAGE_STORAGE_KEY = 'kinhdoLanguage';
     const savedLanguage = localStorage.getItem(LANGUAGE_STORAGE_KEY);
@@ -651,6 +755,7 @@
 
       localStorage.setItem(AGE_GATE_STORAGE_KEY, 'verified');
       localStorage.setItem(AGE_GATE_BIRTH_YEAR_KEY, String(selectedBirthYear));
+      updateGenerationFromBirthYear(selectedBirthYear);
       setAgeGateMessage(null);
       hideAgeGate();
     };
@@ -723,13 +828,8 @@
 
       measureOptionHeight();
 
-      const storedYear = parseInt(localStorage.getItem(AGE_GATE_BIRTH_YEAR_KEY), 10);
-      const defaultYear =
-        Number.isInteger(storedYear) &&
-        storedYear >= AGE_GATE_YEAR_START &&
-        storedYear <= AGE_GATE_YEAR_END
-          ? storedYear
-          : 2000;
+      const storedYear = parseBirthYear(localStorage.getItem(AGE_GATE_BIRTH_YEAR_KEY));
+      const defaultYear = Number.isInteger(storedYear) ? storedYear : 2000;
 
       scrollToYear(defaultYear, 'auto');
       snapToNearest('auto');
@@ -815,6 +915,7 @@
     const setLanguage = (language) => {
       const locale = language === 'vi' ? 'vi' : 'en';
       currentLanguage = locale;
+      applyGenerationMode();
       applyTranslations(locale);
       updateToggleLabel(locale);
       updateAgeGateLanguage(locale);

--- a/products.html
+++ b/products.html
@@ -134,7 +134,7 @@
           <h2 id="featured-products" data-i18n="featuredHeading">Sản phẩm nổi bật</h2>
           <p data-i18n="featuredDescription">Những phiên bản theo mùa tôn vinh tay nghề và hương vị đặc trưng của bánh trung thu Kinh Đô.</p>
         </div>
-        <div class="product-grid">
+        <div class="product-grid product-grid--classic" data-generation-group="classic">
           <article class="product-card">
             <figure>
               <img src="products/8934680042567-tet-1.jpg-236424703.png" alt="Ổ bánh mì tươi làm liền của Kinh Đô trong bao bì tiện dụng." />
@@ -162,6 +162,53 @@
               <div class="product-meta">
                 <span class="price" data-i18n="featuredProduct2Price">₫120,000</span>
                 <a class="btn btn-primary" data-i18n="featuredProduct2Cta" href="contact.html">Thêm vào đơn</a>
+              </div>
+            </div>
+          </article>
+        </div>
+        <div class="product-grid product-grid--genz" data-generation-group="genZ" hidden>
+          <article class="product-card">
+            <figure>
+              <img src="Gen%20Z/chabong.jpg" alt="Pork floss lava mooncake gift box with neon accents." loading="lazy" />
+            </figure>
+            <div class="product-info">
+              <div>
+                <h3 data-i18n="featuredGenZProduct1Title">Pork Floss Lava Mooncake</h3>
+                <p data-i18n="featuredGenZProduct1Description">Savory pork floss folded into silky custard with molten salted egg for midnight feasts.</p>
+              </div>
+              <div class="product-meta">
+                <span class="price" data-i18n="featuredGenZProduct1Price">₫165,000</span>
+                <a class="btn btn-primary" data-i18n="featuredGenZProduct1Cta" href="contact.html">Add to Order</a>
+              </div>
+            </div>
+          </article>
+          <article class="product-card">
+            <figure>
+              <img src="Gen%20Z/socila.jpg" alt="Chocolate mooncake drizzled with rich cacao sauce." loading="lazy" />
+            </figure>
+            <div class="product-info">
+              <div>
+                <h3 data-i18n="featuredGenZProduct2Title">Chocolate Drip Mooncake</h3>
+                <p data-i18n="featuredGenZProduct2Description">Velvety cacao custard with crunchy cocoa nibs and a glossy ganache centre.</p>
+              </div>
+              <div class="product-meta">
+                <span class="price" data-i18n="featuredGenZProduct2Price">₫150,000</span>
+                <a class="btn btn-primary" data-i18n="featuredGenZProduct2Cta" href="contact.html">Add to Order</a>
+              </div>
+            </div>
+          </article>
+          <article class="product-card">
+            <figure>
+              <img src="Gen%20Z/trungtanchayphomai2025.jpg" alt="Melted egg yolk mooncake with gooey filling." loading="lazy" />
+            </figure>
+            <div class="product-info">
+              <div>
+                <h3 data-i18n="featuredGenZProduct3Title">Melted Eggs Mooncake</h3>
+                <p data-i18n="featuredGenZProduct3Description">Cheesy salted egg lava that streams from every slice, created for sharing clips.</p>
+              </div>
+              <div class="product-meta">
+                <span class="price" data-i18n="featuredGenZProduct3Price">₫185,000</span>
+                <a class="btn btn-primary" data-i18n="featuredGenZProduct3Cta" href="contact.html">Add to Order</a>
               </div>
             </div>
           </article>
@@ -275,6 +322,21 @@
           'Chewy snow-skin mooncake filled with pandan green bean paste and crunchy melon seeds for a modern twist.',
         featuredProduct2Price: '₫120,000',
         featuredProduct2Cta: 'Add to Order',
+        featuredGenZProduct1Title: 'Pork Floss Lava Mooncake',
+        featuredGenZProduct1Description:
+          'Savory pork floss folded into silky custard with molten salted egg made for midnight celebrations.',
+        featuredGenZProduct1Price: '₫165,000',
+        featuredGenZProduct1Cta: 'Add to Order',
+        featuredGenZProduct2Title: 'Chocolate Drip Mooncake',
+        featuredGenZProduct2Description:
+          'Velvety cacao custard with crunchy cocoa nibs and a glossy ganache centre for sweet-tooth night owls.',
+        featuredGenZProduct2Price: '₫150,000',
+        featuredGenZProduct2Cta: 'Add to Order',
+        featuredGenZProduct3Title: 'Melted Eggs Mooncake',
+        featuredGenZProduct3Description:
+          'Cheese-kissed salted egg lava that streams from every slice, perfect for sharing reels with friends.',
+        featuredGenZProduct3Price: '₫185,000',
+        featuredGenZProduct3Cta: 'Add to Order',
         spotlightHeading: 'Mooncakes Illuminated',
         spotlightDescription:
           'Every mooncake is a story of artistry — from responsibly sourced ingredients to the final brush of gold. Our chefs balance tradition with contemporary flavours to create experiences that linger beyond the festival night.',
@@ -348,6 +410,21 @@
           'Bánh dẻo kiểu tuyết với nhân đậu xanh lá dứa và hạt dưa giòn mang hơi thở hiện đại.',
         featuredProduct2Price: '₫120,000',
         featuredProduct2Cta: 'Thêm vào đơn',
+        featuredGenZProduct1Title: 'Bánh lava chà bông',
+        featuredGenZProduct1Description:
+          'Chà bông mặn hòa quyện custard sánh mịn cùng nhân trứng muối tan chảy cho bữa tiệc đêm.',
+        featuredGenZProduct1Price: '₫165,000',
+        featuredGenZProduct1Cta: 'Thêm vào đơn',
+        featuredGenZProduct2Title: 'Bánh socola phủ chảy',
+        featuredGenZProduct2Description:
+          'Custard cacao mịn với hạt cacao rang và lõi ganache óng ánh dành cho team hảo ngọt.',
+        featuredGenZProduct2Price: '₫150,000',
+        featuredGenZProduct2Cta: 'Thêm vào đơn',
+        featuredGenZProduct3Title: 'Bánh trứng tan chảy',
+        featuredGenZProduct3Description:
+          'Lava trứng muối quyện phô mai kéo sợi, cắt miếng là tràn để quay clip bắt trend cùng bạn bè.',
+        featuredGenZProduct3Price: '₫185,000',
+        featuredGenZProduct3Cta: 'Thêm vào đơn',
         spotlightHeading: 'Bánh trung thu tỏa sáng',
         spotlightDescription:
           'Mỗi chiếc bánh là câu chuyện nghệ thuật — từ nguyên liệu truy xuất bền vững đến nét cọ vàng cuối cùng. Đầu bếp cân bằng truyền thống và hương vị đương đại để dư âm vượt đêm rằm.',
@@ -384,6 +461,9 @@
     const AGE_GATE_YEAR_START = 1945;
     const AGE_GATE_YEAR_END = 2025;
     const AGE_GATE_FILLER_COUNT = 2;
+    const GEN_Z_YEAR_THRESHOLD = 1997;
+    const GENERATION_CLASSIC = 'classic';
+    const GENERATION_GEN_Z = 'genZ';
 
     const translatableElements = document.querySelectorAll('[data-i18n]');
     const languageToggle = document.getElementById('language-toggle');
@@ -393,6 +473,74 @@
     const ageGateCloseButton = document.getElementById('age-gate-close');
     const ageGateConfirmButton = document.getElementById('age-gate-confirm');
     const ageGateFootnote = document.getElementById('age-gate-footnote');
+    const generationAwareElements = document.querySelectorAll('[data-i18n-classic], [data-i18n-genz]');
+    const heroCardImage = document.querySelector('.hero-card-media img');
+    const generationGroups = document.querySelectorAll('[data-generation-group]');
+    const heroCardMediaConfig = {
+      [GENERATION_CLASSIC]: null,
+      [GENERATION_GEN_Z]: null
+    };
+
+    function parseBirthYear(value) {
+      const year = Number.parseInt(value, 10);
+      if (!Number.isInteger(year)) {
+        return null;
+      }
+      if (year < AGE_GATE_YEAR_START || year > AGE_GATE_YEAR_END) {
+        return null;
+      }
+      return year;
+    }
+
+    function determineGenerationFromBirthYear(year) {
+      if (Number.isInteger(year) && year > GEN_Z_YEAR_THRESHOLD) {
+        return GENERATION_GEN_Z;
+      }
+      return GENERATION_CLASSIC;
+    }
+
+    function applyGenerationMode() {
+      const isGenZ = currentGeneration === GENERATION_GEN_Z;
+
+      document.body.classList.toggle('generation-genz', isGenZ);
+      document.body.classList.toggle('generation-classic', !isGenZ);
+
+      generationAwareElements.forEach((element) => {
+        const targetKey = isGenZ ? element.dataset.i18nGenz : element.dataset.i18nClassic;
+        if (targetKey) {
+          element.dataset.i18n = targetKey;
+        }
+      });
+
+      if (heroCardImage) {
+        const config = heroCardMediaConfig[isGenZ ? GENERATION_GEN_Z : GENERATION_CLASSIC];
+        if (config?.src && heroCardImage.getAttribute('src') !== config.src) {
+          heroCardImage.setAttribute('src', config.src);
+        }
+        if (config?.alt) {
+          const altText = config.alt[currentLanguage] ?? config.alt.en;
+          if (altText) {
+            heroCardImage.setAttribute('alt', altText);
+          }
+        }
+      }
+
+      generationGroups.forEach((group) => {
+        const mode = group.dataset.generationGroup;
+        if (mode === GENERATION_GEN_Z) {
+          group.hidden = !isGenZ;
+        } else if (mode === GENERATION_CLASSIC) {
+          group.hidden = isGenZ;
+        }
+      });
+    }
+
+    function updateGenerationFromBirthYear(year) {
+      const parsedYear = typeof year === 'number' ? year : parseBirthYear(year);
+      currentGeneration = determineGenerationFromBirthYear(parsedYear);
+      applyGenerationMode();
+      applyTranslations(currentLanguage);
+    }
 
     let agePickerOptions = [];
     let agePickerOptionHeight = 0;
@@ -400,6 +548,9 @@
     let selectedBirthYear = null;
     let ageGateInitialized = false;
     let agePickerScrollTimeout;
+    let currentGeneration = determineGenerationFromBirthYear(
+      parseBirthYear(localStorage.getItem(AGE_GATE_BIRTH_YEAR_KEY))
+    );
 
     const LANGUAGE_STORAGE_KEY = 'kinhdoLanguage';
     const savedLanguage = localStorage.getItem(LANGUAGE_STORAGE_KEY);
@@ -697,6 +848,7 @@
 
       localStorage.setItem(AGE_GATE_STORAGE_KEY, 'verified');
       localStorage.setItem(AGE_GATE_BIRTH_YEAR_KEY, String(selectedBirthYear));
+      updateGenerationFromBirthYear(selectedBirthYear);
       setAgeGateMessage(null);
       hideAgeGate();
     };
@@ -769,13 +921,8 @@
 
       measureOptionHeight();
 
-      const storedYear = parseInt(localStorage.getItem(AGE_GATE_BIRTH_YEAR_KEY), 10);
-      const defaultYear =
-        Number.isInteger(storedYear) &&
-        storedYear >= AGE_GATE_YEAR_START &&
-        storedYear <= AGE_GATE_YEAR_END
-          ? storedYear
-          : 2000;
+      const storedYear = parseBirthYear(localStorage.getItem(AGE_GATE_BIRTH_YEAR_KEY));
+      const defaultYear = Number.isInteger(storedYear) ? storedYear : 2000;
 
       scrollToYear(defaultYear, 'auto');
       snapToNearest('auto');
@@ -861,6 +1008,7 @@
     const setLanguage = (language) => {
       const locale = language === 'vi' ? 'vi' : 'en';
       currentLanguage = locale;
+      applyGenerationMode();
       applyTranslations(locale);
       updateToggleLabel(locale);
       updateAgeGateLanguage(locale);

--- a/styles.css
+++ b/styles.css
@@ -36,6 +36,18 @@
       display: block;
     }
 
+    [data-generation-group][hidden] {
+      display: none !important;
+    }
+
+    body.generation-genz [data-generation-group="classic"] {
+      display: none !important;
+    }
+
+    body.generation-classic [data-generation-group="genZ"] {
+      display: none !important;
+    }
+
     a {
       text-decoration: none;
       color: inherit;
@@ -662,6 +674,10 @@
       gap: 1.75rem;
     }
 
+    .product-grid--genz {
+      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    }
+
     .product-card {
       background: rgba(255, 255, 255, 0.9);
       border-radius: var(--rounded-medium);
@@ -1027,6 +1043,10 @@
       .product-grid {
         grid-template-columns: repeat(2, minmax(0, 1fr));
       }
+
+      .product-grid--genz {
+        grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+      }
     }
 
     @media (min-width: 1024px) {
@@ -1052,5 +1072,9 @@
 
       .product-grid {
         grid-template-columns: repeat(2, minmax(0, 1fr));
+      }
+
+      .product-grid--genz {
+        grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
       }
     }


### PR DESCRIPTION
## Summary
- personalize the home page hero card for Gen Z visitors with new lava mooncake content, imagery, and translations
- restructure the featured products section to swap in a three-item Gen Z lineup while keeping classic products for other guests
- add shared generation-aware scripting and responsive styling to toggle content and optimize mobile presentation

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68cac26b5b748322b0fc2f97f4e64049