### PR TITLE
Add responsive imagery to story and sustainability sections

### DIFF
--- a/index.html
+++ b/index.html
@@ -145,6 +145,13 @@
         <div class="story-grid">
           <article class="card story-card">
             <h3 data-i18n="storyCard1Title">Handcrafted Beginnings</h3>
+            <figure class="story-card-media">
+              <img
+                src="harmony/53935006018_51ac6bcc41_h-450241852.jpg"
+                alt="Founders preparing mooncakes by hand in the first Kinh Do bakery."
+                loading="lazy"
+              />
+            </figure>
             <p data-i18n="storyCard1Description">
               Brothers Tran and Nguyen opened the first Kinh Do bakery, experimenting with family recipes and inviting
               neighbours to taste the very first lotus seed mooncakes.
@@ -152,6 +159,13 @@
           </article>
           <article class="card story-card">
             <h3 data-i18n="storyCard2Title">Growing With Vietnam</h3>
+            <figure class="story-card-media">
+              <img
+                src="harmony/helping.jpg"
+                alt="Team members supporting communities across Vietnam during Kinh Do's expansion."
+                loading="lazy"
+              />
+            </figure>
             <p data-i18n="storyCard2Description">
               Throughout the 2000s we expanded across the country, introducing breads, biscuits, and festive hampers
               that brightened celebrations in every province.
@@ -159,6 +173,13 @@
           </article>
           <article class="card story-card">
             <h3 data-i18n="storyCard3Title">Sharing the Glow Worldwide</h3>
+            <figure class="story-card-media">
+              <img
+                src="harmony/helping.jpg"
+                alt="Kinh Do ambassadors sharing mooncakes with communities around the world."
+                loading="lazy"
+              />
+            </figure>
             <p data-i18n="storyCard3Description">
               Today our artisanal mooncakes travel globally, connecting Vietnamese communities with meaningful flavours
               and design-led gifting experiences.
@@ -172,6 +193,13 @@
       <div class="container sustainability">
         <div class="section-heading">
           <h2 data-i18n="sustainabilityHeading">Savour the Future Responsibly</h2>
+          <figure class="section-heading-media">
+            <img
+              src="harmony/Tree-Planting-2-82283855.jpg"
+              alt="Volunteers planting young trees as part of Kinh Do's sustainability commitments."
+              loading="lazy"
+            />
+          </figure>
           <p data-i18n="sustainabilityIntro">Every celebration can be mindful. We champion thoughtful sourcing and packaging for the next generation.</p>
         </div>
         <div class="sustainability-grid">

--- a/styles.css
+++ b/styles.css
@@ -749,9 +749,40 @@
       text-align: left;
     }
 
+    .story-card-media {
+      margin: 0 0 1rem;
+      border-radius: var(--rounded-medium);
+      overflow: hidden;
+      box-shadow: var(--shadow-soft);
+      aspect-ratio: 4 / 3;
+    }
+
+    .story-card-media img {
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+    }
+
     .story-card p {
       margin: 0;
       color: var(--text-muted);
+    }
+
+    .section-heading-media {
+      margin: clamp(1rem, 3vw, 1.5rem) auto;
+      border-radius: var(--rounded-medium);
+      overflow: hidden;
+      box-shadow: var(--shadow-soft);
+      max-width: 520px;
+      width: 100%;
+      aspect-ratio: 4 / 3;
+    }
+
+    .section-heading-media img {
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+      display: block;
     }
 
     .heritage-grid {


### PR DESCRIPTION
## Summary
- embed new historical and community photography within the Our Story cards
- feature sustainability tree-planting imagery beneath the Savour the Future heading
- style the added media for responsive layouts across desktop and mobile

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68cacc346370832286a829bf56ecbca9