### PR TITLE
Update imagery for global story and hero card

### DIFF
--- a/index.html
+++ b/index.html
@@ -175,7 +175,7 @@
             <h3 data-i18n="storyCard3Title">Sharing the Glow Worldwide</h3>
             <figure class="story-card-media">
               <img
-                src="harmony/helping.jpg"
+                src="harmony/worldwide.jpg"
                 alt="Kinh Do ambassadors sharing mooncakes with communities around the world."
                 loading="lazy"
               />

--- a/styles.css
+++ b/styles.css
@@ -452,8 +452,7 @@
 
     .hero-card-media img {
       width: 100%;
-      aspect-ratio: 4 / 3;
-      object-fit: cover;
+      height: auto;
       display: block;
     }
 


### PR DESCRIPTION
## Summary
- update the global story card to display the worldwide celebration image
- adjust hero card media styling so the 25-year anniversary set photo keeps its full framing

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cace2b468883228342c516d4a2a380