### PR TITLE
Add mobile header hide/show interaction

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -696,6 +696,75 @@
       }
     };
 
+    const siteHeader = document.querySelector('.site-header');
+    const mobileHeaderQuery = window.matchMedia('(max-width: 720px)');
+    let lastKnownScrollY = window.scrollY;
+    let headerHidden = false;
+
+    const showSiteHeader = () => {
+      if (!siteHeader || !headerHidden) return;
+      siteHeader.classList.remove('is-hidden');
+      headerHidden = false;
+    };
+
+    const hideSiteHeader = () => {
+      if (!siteHeader || headerHidden) return;
+      siteHeader.classList.add('is-hidden');
+      headerHidden = true;
+    };
+
+    const evaluateHeaderVisibility = () => {
+      if (!siteHeader) return;
+
+      if (!mobileHeaderQuery.matches) {
+        showSiteHeader();
+        lastKnownScrollY = window.scrollY;
+        return;
+      }
+
+      const currentScrollY = Math.max(window.scrollY, 0);
+      const isScrollingDown = currentScrollY > lastKnownScrollY;
+      const shouldHide = isScrollingDown && currentScrollY > 80;
+
+      if (shouldHide) {
+        hideSiteHeader();
+      } else {
+        showSiteHeader();
+      }
+
+      lastKnownScrollY = currentScrollY;
+    };
+
+    const resetHeaderVisibility = () => {
+      lastKnownScrollY = window.scrollY;
+      if (!siteHeader) return;
+      siteHeader.classList.remove('is-hidden');
+      headerHidden = false;
+    };
+
+    if (siteHeader) {
+      window.addEventListener('scroll', evaluateHeaderVisibility, { passive: true });
+      window.addEventListener('orientationchange', () => {
+        resetHeaderVisibility();
+        evaluateHeaderVisibility();
+      });
+
+      const handleMobileQueryChange = () => {
+        resetHeaderVisibility();
+        if (mobileHeaderQuery.matches) {
+          evaluateHeaderVisibility();
+        }
+      };
+
+      if (typeof mobileHeaderQuery.addEventListener === 'function') {
+        mobileHeaderQuery.addEventListener('change', handleMobileQueryChange);
+      } else if (typeof mobileHeaderQuery.addListener === 'function') {
+        mobileHeaderQuery.addListener(handleMobileQueryChange);
+      }
+
+      evaluateHeaderVisibility();
+    }
+
     const setLanguage = (language) => {
       const locale = language === 'vi' ? 'vi' : 'en';
       currentLanguage = locale;

--- a/index.html
+++ b/index.html
@@ -940,6 +940,75 @@
       }
     };
 
+    const siteHeader = document.querySelector('.site-header');
+    const mobileHeaderQuery = window.matchMedia('(max-width: 720px)');
+    let lastKnownScrollY = window.scrollY;
+    let headerHidden = false;
+
+    const showSiteHeader = () => {
+      if (!siteHeader || !headerHidden) return;
+      siteHeader.classList.remove('is-hidden');
+      headerHidden = false;
+    };
+
+    const hideSiteHeader = () => {
+      if (!siteHeader || headerHidden) return;
+      siteHeader.classList.add('is-hidden');
+      headerHidden = true;
+    };
+
+    const evaluateHeaderVisibility = () => {
+      if (!siteHeader) return;
+
+      if (!mobileHeaderQuery.matches) {
+        showSiteHeader();
+        lastKnownScrollY = window.scrollY;
+        return;
+      }
+
+      const currentScrollY = Math.max(window.scrollY, 0);
+      const isScrollingDown = currentScrollY > lastKnownScrollY;
+      const shouldHide = isScrollingDown && currentScrollY > 80;
+
+      if (shouldHide) {
+        hideSiteHeader();
+      } else {
+        showSiteHeader();
+      }
+
+      lastKnownScrollY = currentScrollY;
+    };
+
+    const resetHeaderVisibility = () => {
+      lastKnownScrollY = window.scrollY;
+      if (!siteHeader) return;
+      siteHeader.classList.remove('is-hidden');
+      headerHidden = false;
+    };
+
+    if (siteHeader) {
+      window.addEventListener('scroll', evaluateHeaderVisibility, { passive: true });
+      window.addEventListener('orientationchange', () => {
+        resetHeaderVisibility();
+        evaluateHeaderVisibility();
+      });
+
+      const handleMobileQueryChange = () => {
+        resetHeaderVisibility();
+        if (mobileHeaderQuery.matches) {
+          evaluateHeaderVisibility();
+        }
+      };
+
+      if (typeof mobileHeaderQuery.addEventListener === 'function') {
+        mobileHeaderQuery.addEventListener('change', handleMobileQueryChange);
+      } else if (typeof mobileHeaderQuery.addListener === 'function') {
+        mobileHeaderQuery.addListener(handleMobileQueryChange);
+      }
+
+      evaluateHeaderVisibility();
+    }
+
     const setLanguage = (language) => {
       const locale = language === 'vi' ? 'vi' : 'en';
       currentLanguage = locale;

--- a/products.html
+++ b/products.html
@@ -1005,6 +1005,75 @@
       }
     };
 
+    const siteHeader = document.querySelector('.site-header');
+    const mobileHeaderQuery = window.matchMedia('(max-width: 720px)');
+    let lastKnownScrollY = window.scrollY;
+    let headerHidden = false;
+
+    const showSiteHeader = () => {
+      if (!siteHeader || !headerHidden) return;
+      siteHeader.classList.remove('is-hidden');
+      headerHidden = false;
+    };
+
+    const hideSiteHeader = () => {
+      if (!siteHeader || headerHidden) return;
+      siteHeader.classList.add('is-hidden');
+      headerHidden = true;
+    };
+
+    const evaluateHeaderVisibility = () => {
+      if (!siteHeader) return;
+
+      if (!mobileHeaderQuery.matches) {
+        showSiteHeader();
+        lastKnownScrollY = window.scrollY;
+        return;
+      }
+
+      const currentScrollY = Math.max(window.scrollY, 0);
+      const isScrollingDown = currentScrollY > lastKnownScrollY;
+      const shouldHide = isScrollingDown && currentScrollY > 80;
+
+      if (shouldHide) {
+        hideSiteHeader();
+      } else {
+        showSiteHeader();
+      }
+
+      lastKnownScrollY = currentScrollY;
+    };
+
+    const resetHeaderVisibility = () => {
+      lastKnownScrollY = window.scrollY;
+      if (!siteHeader) return;
+      siteHeader.classList.remove('is-hidden');
+      headerHidden = false;
+    };
+
+    if (siteHeader) {
+      window.addEventListener('scroll', evaluateHeaderVisibility, { passive: true });
+      window.addEventListener('orientationchange', () => {
+        resetHeaderVisibility();
+        evaluateHeaderVisibility();
+      });
+
+      const handleMobileQueryChange = () => {
+        resetHeaderVisibility();
+        if (mobileHeaderQuery.matches) {
+          evaluateHeaderVisibility();
+        }
+      };
+
+      if (typeof mobileHeaderQuery.addEventListener === 'function') {
+        mobileHeaderQuery.addEventListener('change', handleMobileQueryChange);
+      } else if (typeof mobileHeaderQuery.addListener === 'function') {
+        mobileHeaderQuery.addListener(handleMobileQueryChange);
+      }
+
+      evaluateHeaderVisibility();
+    }
+
     const setLanguage = (language) => {
       const locale = language === 'vi' ? 'vi' : 'en';
       currentLanguage = locale;

--- a/styles.css
+++ b/styles.css
@@ -246,6 +246,20 @@
       background: rgba(255, 247, 244, 0.9);
       backdrop-filter: blur(14px);
       border-bottom: 1px solid rgba(215, 31, 38, 0.1);
+      transition: transform 0.28s ease, opacity 0.28s ease;
+      will-change: transform;
+    }
+
+    header.site-header.is-hidden {
+      transform: translateY(-100%);
+      opacity: 0;
+      pointer-events: none;
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      header.site-header {
+        transition: none;
+      }
     }
 
     .nav-bar {


### PR DESCRIPTION
## Summary
- animate the sticky header so it slides out of view on downward scrolls in mobile viewports and returns when scrolling up
- update all pages to initialize the mobile header controller alongside existing scripts for consistent behaviour
- add reduced-motion guard to respect user accessibility preferences

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cad46104c48322a6ad4ae78442717d