### PR TITLE
Update classic mooncakes for pre-1997 visitors

### DIFF
--- a/products.html
+++ b/products.html
@@ -137,31 +137,46 @@
         <div class="product-grid product-grid--classic" data-generation-group="classic">
           <article class="product-card">
             <figure>
-              <img src="products/8934680042567-tet-1.jpg-236424703.png" alt="Ổ bánh mì tươi làm liền của Kinh Đô trong bao bì tiện dụng." />
+              <img src="Gen%20Z/Non%20gen%20Z/thapcam.jpg" alt="Bánh trung thu nhân thập cẩm với lớp vỏ nướng vàng óng." />
             </figure>
             <div class="product-info">
               <div>
-                <h3 data-i18n="featuredProduct1Title">Bánh mì tươi làm liền</h3>
-                <p data-i18n="featuredProduct1Description">Ổ bánh mì mềm mới nướng, đóng gói tiện lợi để làm nóng và thưởng thức ngay.</p>
+                <h3 data-i18n="featuredProduct1Title">Nhân thập cẩm</h3>
+                <p data-i18n="featuredProduct1Description">Hương vị truyền thống kết hợp các loại hạt, mứt và jambon tạo nên lớp nhân mặn ngọt hài hòa.</p>
               </div>
               <div class="product-meta">
-                <span class="price" data-i18n="featuredProduct1Price">32.000 VND</span>
+                <span class="price" data-i18n="featuredProduct1Price">₫185,000</span>
                 <a class="btn btn-primary" data-i18n="featuredProduct1Cta" href="contact.html">Đặt trước ngay</a>
               </div>
             </div>
           </article>
           <article class="product-card">
             <figure>
-              <img src="products/banh-trung-thu-kinh-do-deo-dau-xanh-hat-dua-0-trung-230gr-3901982844.jpg" alt="Bánh dẻo đậu xanh lá dứa của Kinh Đô." />
+              <img src="Gen%20Z/Non%20gen%20Z/dauxanh.jpg" alt="Bánh trung thu nhân đậu xanh với lớp vỏ nướng mềm mịn." />
             </figure>
             <div class="product-info">
               <div>
-                <h3 data-i18n="featuredProduct2Title">Bánh dẻo đậu xanh mềm</h3>
-                <p data-i18n="featuredProduct2Description">Bánh dẻo kiểu tuyết với nhân đậu xanh lá dứa và hạt dưa giòn mang hơi thở hiện đại.</p>
+                <h3 data-i18n="featuredProduct2Title">Nhân đậu xanh</h3>
+                <p data-i18n="featuredProduct2Description">Nhân đậu xanh mịn màng phảng phất lá dứa, cân bằng cùng vỏ bánh nướng mềm.</p>
               </div>
               <div class="product-meta">
-                <span class="price" data-i18n="featuredProduct2Price">₫120,000</span>
+                <span class="price" data-i18n="featuredProduct2Price">₫150,000</span>
                 <a class="btn btn-primary" data-i18n="featuredProduct2Cta" href="contact.html">Thêm vào đơn</a>
+              </div>
+            </div>
+          </article>
+          <article class="product-card">
+            <figure>
+              <img src="Gen%20Z/Non%20gen%20Z/banh-trung-thu-kido-sua-dua-hat-dua-850877000.png" alt="Bánh trung thu nhân sữa dừa với sợi dừa nướng thơm béo." />
+            </figure>
+            <div class="product-info">
+              <div>
+                <h3 data-i18n="featuredProduct3Title">Nhân sữa dừa</h3>
+                <p data-i18n="featuredProduct3Description">Custard sữa dừa béo ngậy quyện sợi dừa nướng, đem đến dư vị nhiệt đới tinh tế.</p>
+              </div>
+              <div class="product-meta">
+                <span class="price" data-i18n="featuredProduct3Price">₫165,000</span>
+                <a class="btn btn-primary" data-i18n="featuredProduct3Cta" href="contact.html">Thêm vào đơn</a>
               </div>
             </div>
           </article>
@@ -312,16 +327,21 @@
         featuredHeading: 'Featured Products',
         featuredDescription:
           'Limited seasonal releases that highlight the craftsmanship and flavours at the heart of Kinh Do mooncakes.',
-        featuredProduct1Title: 'Freshly Made Instant Bread',
+        featuredProduct1Title: 'Mixed Ingredient Mooncake',
         featuredProduct1Description:
-          'Soft loaves baked at dawn, sealed for quick heat-and-serve enjoyment any time.',
-        featuredProduct1Price: '32.000 VND',
+          'A savoury-sweet medley of nuts, seeds, and charcuterie wrapped in a classic baked crust.',
+        featuredProduct1Price: '₫185,000',
         featuredProduct1Cta: 'Reserve Now',
-        featuredProduct2Title: 'Soft Green Bean Mochi Cake',
+        featuredProduct2Title: 'Green Bean Mooncake',
         featuredProduct2Description:
-          'Chewy snow-skin mooncake filled with pandan green bean paste and crunchy melon seeds for a modern twist.',
-        featuredProduct2Price: '₫120,000',
+          'Silky mung bean filling with a whisper of pandan nestled inside a tender golden pastry.',
+        featuredProduct2Price: '₫150,000',
         featuredProduct2Cta: 'Add to Order',
+        featuredProduct3Title: 'Coconut Milk Mooncake',
+        featuredProduct3Description:
+          'Fragrant coconut milk custard folded with toasted coconut ribbons for a tropical finish.',
+        featuredProduct3Price: '₫165,000',
+        featuredProduct3Cta: 'Add to Order',
         featuredGenZProduct1Title: 'Pork Floss Lava Mooncake',
         featuredGenZProduct1Description:
           'Savory pork floss folded into silky custard with molten salted egg made for midnight celebrations.',
@@ -400,16 +420,21 @@
         featuredHeading: 'Sản phẩm nổi bật',
         featuredDescription:
           'Những phiên bản theo mùa tôn vinh tay nghề và hương vị đặc trưng của bánh trung thu Kinh Đô.',
-        featuredProduct1Title: 'Bánh mì tươi làm liền',
+        featuredProduct1Title: 'Nhân thập cẩm',
         featuredProduct1Description:
-          'Ổ bánh mì mềm mới nướng, đóng gói tiện lợi để làm nóng và thưởng thức ngay.',
-        featuredProduct1Price: '32.000 VND',
+          'Sự hòa quyện của các loại hạt, mứt và jambon trong lớp vỏ bánh nướng truyền thống.',
+        featuredProduct1Price: '₫185,000',
         featuredProduct1Cta: 'Đặt trước ngay',
-        featuredProduct2Title: 'Bánh dẻo đậu xanh mềm',
+        featuredProduct2Title: 'Nhân đậu xanh',
         featuredProduct2Description:
-          'Bánh dẻo kiểu tuyết với nhân đậu xanh lá dứa và hạt dưa giòn mang hơi thở hiện đại.',
-        featuredProduct2Price: '₫120,000',
+          'Nhân đậu xanh mịn màng thoảng hương lá dứa ôm trọn trong lớp vỏ bánh vàng mềm.',
+        featuredProduct2Price: '₫150,000',
         featuredProduct2Cta: 'Thêm vào đơn',
+        featuredProduct3Title: 'Nhân sữa dừa',
+        featuredProduct3Description:
+          'Custard sữa dừa béo ngậy quyện sợi dừa nướng mang đến trải nghiệm nhiệt đới tinh tế.',
+        featuredProduct3Price: '₫165,000',
+        featuredProduct3Cta: 'Thêm vào đơn',
         featuredGenZProduct1Title: 'Bánh lava chà bông',
         featuredGenZProduct1Description:
           'Chà bông mặn hòa quyện custard sánh mịn cùng nhân trứng muối tan chảy cho bữa tiệc đêm.',


### PR DESCRIPTION
## Summary
- replace the classic featured products with three traditional mooncakes and updated imagery for non-Gen Z visitors
- refresh English and Vietnamese translations with new titles, descriptions, and prices for the classic lineup

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68cadd0f47b48322be8170af29c1343c