### PR TITLE
Widen Our Story images on mobile

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1013,7 +1013,7 @@
       }
 
       .story-card-media {
-        aspect-ratio: 3 / 4;
+        aspect-ratio: 16 / 9;
       }
 
       .photo-gallery .container {


### PR DESCRIPTION
## Summary
- update the mobile media query for the Our Story cards to use a wider 16:9 aspect ratio so images fill more horizontal space on phones

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68cb55d1f3c88322aab12bee0115e7fc