### PR TITLE
Show full Gen Z hero image without cropping

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -621,6 +621,15 @@
       object-fit: cover;
     }
 
+    body.generation-genz .hero--home .hero-card-media {
+      aspect-ratio: auto;
+    }
+
+    body.generation-genz .hero--home .hero-card-media img {
+      height: auto;
+      object-fit: contain;
+    }
+
     .stat-card {
       background: rgba(255, 255, 255, 0.78);
       padding: 1.25rem 1.5rem;


### PR DESCRIPTION
## Summary
- add generation-specific overrides so the Gen Z hero image keeps its native proportions

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cc1dbce9b88322bb8c33e7d9301562