### PR TITLE
Show full hero mooncake image

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -613,19 +613,9 @@
       border-radius: var(--rounded-medium);
       overflow: hidden;
       box-shadow: 0 18px 40px -30px rgba(0, 0, 0, 0.75);
-      aspect-ratio: 4 / 5;
     }
 
     .hero--home .hero-card-media img {
-      height: 100%;
-      object-fit: cover;
-    }
-
-    body.generation-genz .hero--home .hero-card-media {
-      aspect-ratio: auto;
-    }
-
-    body.generation-genz .hero--home .hero-card-media img {
       height: auto;
       object-fit: contain;
     }


### PR DESCRIPTION
## Summary
- allow the hero card image on the home page to size naturally so the entire mooncake photo stays visible

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cc1f58cb388322bc454b18f9e2039c