### PR TITLE
Add Song Tung feature announcement section

### DIFF
--- a/index.html
+++ b/index.html
@@ -106,6 +106,26 @@
       </div>
     </section>
 
+    <section class="feature-announcement" id="songtung">
+      <div class="container feature-announcement__content">
+        <div class="feature-announcement__text">
+          <h2 class="feature-announcement__title" data-i18n="announcementHeading">
+            Big changes are coming in
+          </h2>
+          <p class="feature-announcement__description" data-i18n="announcementDescription">
+            Món quà ý nghĩa dành tặng cho những người thân yêu. Hộp bánh thủ công tinh xảo, được tô điểm bằng phong cảnh và hoa sen truyền thống, không chỉ là một món ăn ngon mà còn là biểu tượng của sự thanh lịch và tinh tế. Một món quà chứa đựng đầy đủ hương vị và tình cảm, rất phù hợp trong các dịp đặc biệt.
+          </p>
+        </div>
+        <figure class="feature-announcement__media">
+          <img
+            src="songtung.png"
+            alt="Handcrafted mooncake gift box adorned with traditional scenery and lotus blooms."
+            loading="lazy"
+          />
+        </figure>
+      </div>
+    </section>
+
     <section class="photo-gallery" aria-labelledby="gallery-title">
       <div class="container">
         <div class="section-heading">
@@ -265,6 +285,9 @@
           'Custard lava mooncakes with slow-aged salted egg centres crafted for bold-night celebrations.',
         heroCardFootnote1: 'Limited seasonal batch',
         heroCardFootnote2: 'Available now',
+        announcementHeading: 'Big changes are coming in',
+        announcementDescription:
+          'A meaningful gift for loved ones. The handcrafted mooncake box, adorned with traditional landscapes and lotus blossoms, is not only a delicious treat but also a symbol of elegance and sophistication. A gift filled with flavour and affection, perfect for special occasions.',
         galleryHeading: 'Moments from Our Bakery',
         galleryDescription:
           'Glowing lanterns, freshly baked mooncakes, and festive gift sets that celebrate every Mid-Autumn gathering.',
@@ -329,6 +352,9 @@
           'Phiên bản lava sánh mịn cùng trứng muối ủ lâu cho trải nghiệm tan chảy đậm đà.',
         heroCardFootnote1: 'Sản xuất theo mùa giới hạn',
         heroCardFootnote2: 'Đang mở bán',
+        announcementHeading: 'Những đổi mới lớn đang đến',
+        announcementDescription:
+          'Món quà ý nghĩa dành tặng cho những người thân yêu. Hộp bánh thủ công tinh xảo, được tô điểm bằng phong cảnh và hoa sen truyền thống, không chỉ là một món ăn ngon mà còn là biểu tượng của sự thanh lịch và tinh tế. Một món quà chứa đựng đầy đủ hương vị và tình cảm, rất phù hợp trong các dịp đặc biệt.',
         galleryHeading: 'Khoảnh khắc từ tiệm bánh của chúng tôi',
         galleryDescription:
           'Đèn lồng rực rỡ, bánh trung thu mới ra lò và những hộp quà lễ hội tôn vinh mọi mùa đoàn viên.',

--- a/styles.css
+++ b/styles.css
@@ -620,6 +620,63 @@
       object-fit: contain;
     }
 
+    .feature-announcement {
+      position: relative;
+      background: linear-gradient(135deg, rgba(255, 244, 240, 0.9) 0%, rgba(255, 255, 255, 0.95) 100%);
+      overflow: hidden;
+    }
+
+    .feature-announcement::before {
+      content: "";
+      position: absolute;
+      inset: -30% auto auto -10%;
+      width: clamp(220px, 40vw, 320px);
+      height: clamp(220px, 40vw, 320px);
+      background: radial-gradient(circle at 50% 50%, rgba(215, 31, 38, 0.12) 0%, rgba(215, 31, 38, 0) 70%);
+      z-index: 0;
+    }
+
+    .feature-announcement__content {
+      position: relative;
+      z-index: 1;
+      display: grid;
+      gap: clamp(2rem, 6vw, 4rem);
+      align-items: center;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+
+    .feature-announcement__text {
+      display: flex;
+      flex-direction: column;
+      gap: 1.5rem;
+    }
+
+    .feature-announcement__title {
+      margin: 0;
+      font-family: 'Playfair Display', serif;
+      font-size: clamp(2.2rem, 4vw, 3rem);
+      color: var(--brand-dark);
+    }
+
+    .feature-announcement__description {
+      margin: 0;
+      font-size: clamp(1.05rem, 2.2vw, 1.2rem);
+      color: var(--text-muted);
+      font-style: italic;
+    }
+
+    .feature-announcement__media {
+      margin: 0;
+      display: flex;
+      justify-content: center;
+    }
+
+    .feature-announcement__media img {
+      width: min(420px, 100%);
+      border-radius: var(--rounded-large);
+      box-shadow: var(--shadow-soft);
+    }
+
     .stat-card {
       background: rgba(255, 255, 255, 0.78);
       padding: 1.25rem 1.5rem;
@@ -1119,6 +1176,19 @@
       header.site-header {
         position: sticky;
       }
+
+      .feature-announcement__content {
+        grid-template-columns: 1fr;
+        text-align: center;
+      }
+
+      .feature-announcement__text {
+        align-items: center;
+      }
+
+      .feature-announcement__media {
+        order: -1;
+      }
     }
 
     @media (max-width: 600px) {
@@ -1142,6 +1212,10 @@
       .photo-gallery .container {
         width: min(1120px, 100vw);
         padding: 2.5rem 1rem;
+      }
+
+      .feature-announcement__media img {
+        width: min(320px, 100%);
       }
 
       .gallery-card {


### PR DESCRIPTION
## Summary
- add a Song Tùng announcement section with dedicated image and translated copy on the home page
- style the new announcement block for desktop and mobile layouts with italicised description text

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cd8eade3f48322a8eb08996cc68e6a