### PR TITLE
Adjust feature announcement layout

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -639,16 +639,19 @@
     .feature-announcement__content {
       position: relative;
       z-index: 1;
-      display: grid;
+      display: flex;
+      flex-direction: column;
       gap: clamp(2rem, 6vw, 4rem);
       align-items: center;
-      grid-template-columns: repeat(2, minmax(0, 1fr));
+      text-align: center;
     }
 
     .feature-announcement__text {
       display: flex;
       flex-direction: column;
       gap: 1.5rem;
+      align-items: center;
+      max-width: min(720px, 100%);
     }
 
     .feature-announcement__title {
@@ -672,7 +675,7 @@
     }
 
     .feature-announcement__media img {
-      width: min(420px, 100%);
+      width: min(560px, 100%);
       border-radius: var(--rounded-large);
       box-shadow: var(--shadow-soft);
     }
@@ -1178,16 +1181,7 @@
       }
 
       .feature-announcement__content {
-        grid-template-columns: 1fr;
         text-align: center;
-      }
-
-      .feature-announcement__text {
-        align-items: center;
-      }
-
-      .feature-announcement__media {
-        order: -1;
       }
     }
 


### PR DESCRIPTION
## Summary
- stack the feature announcement text above the Song Tùng artwork with a centered layout
- enlarge the Song Tùng image so it stands out more prominently on larger screens

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cd910120ac8322af05a0a30416bd33