### PR TITLE
Adjust feature announcement styling

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -626,15 +626,6 @@
       overflow: hidden;
     }
 
-    .feature-announcement::before {
-      content: "";
-      position: absolute;
-      inset: 0;
-      background: linear-gradient(135deg, rgba(255, 244, 240, 0.9) 0%, rgba(255, 255, 255, 0.65) 100%);
-      backdrop-filter: blur(4px);
-      z-index: 0;
-    }
-
     .feature-announcement__content {
       position: relative;
       z-index: 1;
@@ -652,25 +643,46 @@
       gap: 1.5rem;
       align-items: center;
       max-width: min(720px, 100%);
-      padding: clamp(2rem, 5vw, 3rem);
-      border-radius: var(--rounded-large);
-      background: rgba(255, 255, 255, 0.8);
-      box-shadow: var(--shadow-soft);
-      backdrop-filter: blur(6px);
+      padding: 0;
+      border-radius: 0;
+      background: transparent;
+      box-shadow: none;
+      backdrop-filter: none;
     }
 
     .feature-announcement__title {
       margin: 0;
       font-family: 'Playfair Display', serif;
       font-size: clamp(2.2rem, 4vw, 3rem);
-      color: var(--brand-dark);
+      color: #fff;
+      text-shadow: 0 4px 24px rgba(0, 0, 0, 0.45);
     }
 
     .feature-announcement__description {
       margin: 0;
       font-size: clamp(1.05rem, 2.2vw, 1.2rem);
-      color: var(--text-muted);
+      color: #fff;
       font-style: italic;
+      text-shadow: 0 4px 24px rgba(0, 0, 0, 0.45);
+    }
+
+    @media (max-width: 768px) {
+      .feature-announcement {
+        background-size: contain;
+        background-position: top center;
+        background-repeat: no-repeat;
+        min-height: 150vw;
+      }
+
+      .feature-announcement__content {
+        justify-content: flex-end;
+        padding-top: clamp(2rem, 12vw, 4rem);
+        padding-bottom: clamp(3rem, 16vw, 6rem);
+      }
+
+      .feature-announcement__text {
+        padding: 0 clamp(1rem, 6vw, 2rem);
+      }
     }
 
 


### PR DESCRIPTION
## Summary
- remove the translucent panel and gradient overlay from the feature announcement section so the songtung.png artwork is unobstructed
- restyle the announcement text for readability directly over the image and adjust spacing
- ensure the full vertical songtung.png image displays on mobile by switching to a contain background with an aspect ratio based min-height

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68cd9404b9a883228c789ac15410f754