### PR TITLE
Adjust mobile feature announcement layout

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -671,12 +671,12 @@
         background-size: contain;
         background-position: top center;
         background-repeat: no-repeat;
-        min-height: 150vw;
+        min-height: 185vw;
       }
 
       .feature-announcement__content {
         justify-content: flex-end;
-        padding-top: clamp(2rem, 12vw, 4rem);
+        padding-top: clamp(6rem, 22vw, 10rem);
         padding-bottom: clamp(3rem, 16vw, 6rem);
       }
 


### PR DESCRIPTION
## Summary
- increase the mobile height of the feature announcement section background
- push the announcement copy further down so the artwork stays prominent on phones

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cd955fb4d08322aae90cd65d57a154