### PR TITLE
Adjust announcement spacing and update Vietnamese copy

### DIFF
--- a/index.html
+++ b/index.html
@@ -349,7 +349,7 @@
         heroCardFootnote2: 'Đang mở bán',
         announcementHeading: 'Những đổi mới lớn đang đến',
         announcementDescription:
-          'Món quà ý nghĩa dành tặng những người thân yêu. Hộp bánh Trung Thu thủ công, được trang trí với phong cảnh truyền thống và hoa sen, không chỉ ngon miệng mà còn là biểu tượng của sự tinh tế và sang trọng. Một món quà trọn vẹn hương vị và yêu thương, lý tưởng cho những dịp đặc biệt.',
+          'Hộp bánh Trung Thu thủ công, được trang trí với phong cảnh truyền thống và hoa sen, không chỉ ngon miệng mà còn là biểu tượng của sự tinh tế và sang trọng. Một món quà trọn vẹn hương vị và yêu thương, lý tưởng cho những dịp đặc biệt.',
         galleryHeading: 'Khoảnh khắc từ tiệm bánh của chúng tôi',
         galleryDescription:
           'Đèn lồng rực rỡ, bánh trung thu mới ra lò và những hộp quà lễ hội tôn vinh mọi mùa đoàn viên.',

--- a/styles.css
+++ b/styles.css
@@ -356,6 +356,10 @@
       padding: clamp(4rem, 8vw, 6.5rem) 0;
     }
 
+    main section + section {
+      margin-top: clamp(3rem, 7vw, 5rem);
+    }
+
     .hero {
       position: relative;
       overflow: hidden;
@@ -634,7 +638,8 @@
       gap: clamp(2rem, 6vw, 4rem);
       align-items: center;
       text-align: center;
-      padding: clamp(3rem, 10vw, 6rem) 0;
+      padding-top: clamp(5rem, 12vw, 8rem);
+      padding-bottom: clamp(3rem, 10vw, 6rem);
     }
 
     .feature-announcement__text {


### PR DESCRIPTION
## Summary
- add additional spacing between the hero, announcement, and gallery sections for clearer separation
- push the announcement text lower within its background artwork and update the Vietnamese translation copy

## Testing
- not run (not required)


------
https://chatgpt.com/codex/tasks/task_e_68cd99ff118483228836b03f43ea2d64