### PR TITLE
Adjust mobile spacing for announcement section

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -676,13 +676,13 @@
         background-size: contain;
         background-position: top center;
         background-repeat: no-repeat;
-        min-height: 185vw;
+        min-height: 220vw;
       }
 
       .feature-announcement__content {
         justify-content: flex-end;
-        padding-top: clamp(6rem, 22vw, 10rem);
-        padding-bottom: clamp(3rem, 16vw, 6rem);
+        padding-top: clamp(7rem, 26vw, 12rem);
+        padding-bottom: clamp(2.5rem, 12vw, 5rem);
       }
 
       .feature-announcement__text {


### PR DESCRIPTION
## Summary
- increase the mobile min-height of the announcement feature section so the callout sits lower in the layout
- tweak the mobile padding to drop the announcement text farther down the page

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cd9b46b1dc832282668922ee550d52