### PR TITLE
Adjust mobile announcement spacing

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -681,12 +681,13 @@
 
       .feature-announcement__content {
         justify-content: flex-end;
-        padding-top: clamp(7rem, 26vw, 12rem);
+        padding-top: clamp(10rem, 34vw, 18rem);
         padding-bottom: clamp(2.5rem, 12vw, 5rem);
       }
 
       .feature-announcement__text {
         padding: 0 clamp(1rem, 6vw, 2rem);
+        margin-top: clamp(3rem, 12vw, 6rem);
       }
     }
 


### PR DESCRIPTION
## Summary
- increase top padding for the feature announcement section on small screens
- add additional top margin on the announcement copy to push it further down on mobile

## Testing
- no tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68cd9dd654f88322abf9e0d6f0db8625