### PR TITLE
Add arrow indicator to navigation call-to-action buttons

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -346,6 +346,25 @@
       color: #fff;
     }
 
+    a[data-i18n="navShop"]::after,
+    a[data-i18n="navCta"]::after {
+      content: "\2192";
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      margin-left: 0.5rem;
+      font-size: 1.05em;
+      line-height: 1;
+      transition: transform 0.2s ease;
+    }
+
+    a[data-i18n="navShop"]:hover::after,
+    a[data-i18n="navShop"]:focus-visible::after,
+    a[data-i18n="navCta"]:hover::after,
+    a[data-i18n="navCta"]:focus-visible::after {
+      transform: translateX(4px);
+    }
+
     .btn-ghost {
       background: rgba(255, 255, 255, 0.65);
       border-color: rgba(215, 31, 38, 0.25);


### PR DESCRIPTION
## Summary
- add a decorative right-pointing arrow to the navigation call-to-action buttons for shopping and custom orders
- animate the arrow on hover and focus for a subtle directional cue

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cd9fbcf3248322bead03917234bbdd