### PR TITLE
Enhance announcement text readability with stronger shadow

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -660,7 +660,9 @@
       font-family: 'Playfair Display', serif;
       font-size: clamp(2.2rem, 4vw, 3rem);
       color: #fff;
-      text-shadow: 0 4px 24px rgba(0, 0, 0, 0.45);
+      text-shadow:
+        0 2px 6px rgba(0, 0, 0, 0.5),
+        0 8px 24px rgba(0, 0, 0, 0.55);
     }
 
     .feature-announcement__description {
@@ -668,7 +670,9 @@
       font-size: clamp(1.05rem, 2.2vw, 1.2rem);
       color: #fff;
       font-style: italic;
-      text-shadow: 0 4px 24px rgba(0, 0, 0, 0.45);
+      text-shadow:
+        0 2px 6px rgba(0, 0, 0, 0.45),
+        0 10px 28px rgba(0, 0, 0, 0.6);
     }
 
     @media (max-width: 768px) {


### PR DESCRIPTION
## Summary
- strengthen text-shadow layering for the feature announcement heading and description
- improve contrast against the background artwork for better readability

## Testing
- not run (static CSS update)


------
https://chatgpt.com/codex/tasks/task_e_68cda0101b3c83229eae3417d29edae9