### PR TITLE
Reduce mobile feature spacing and show all products when age is undisclosed

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -543,6 +543,7 @@
 
     const dismissAgeGate = () => {
       localStorage.setItem(AGE_GATE_STORAGE_KEY, 'dismissed');
+      localStorage.removeItem(AGE_GATE_BIRTH_YEAR_KEY);
       setAgeGateMessage(null);
       hideAgeGate();
     };

--- a/index.html
+++ b/index.html
@@ -407,9 +407,12 @@
     const AGE_GATE_YEAR_START = 1945;
     const AGE_GATE_YEAR_END = 2025;
     const AGE_GATE_FILLER_COUNT = 2;
+    const AGE_GATE_STATUS_VERIFIED = 'verified';
+    const AGE_GATE_STATUS_DISMISSED = 'dismissed';
     const GEN_Z_YEAR_THRESHOLD = 1997;
     const GENERATION_CLASSIC = 'classic';
     const GENERATION_GEN_Z = 'genZ';
+    const GENERATION_ALL = 'all';
 
     const translatableElements = document.querySelectorAll('[data-i18n]');
     const languageToggle = document.getElementById('language-toggle');
@@ -458,20 +461,28 @@
     }
 
     function applyGenerationMode() {
+      const showAllGenerations = currentGeneration === GENERATION_ALL;
       const isGenZ = currentGeneration === GENERATION_GEN_Z;
 
-      document.body.classList.toggle('generation-genz', isGenZ);
-      document.body.classList.toggle('generation-classic', !isGenZ);
+      document.body.classList.remove('generation-genz', 'generation-classic');
+      if (isGenZ) {
+        document.body.classList.add('generation-genz');
+      } else if (currentGeneration === GENERATION_CLASSIC) {
+        document.body.classList.add('generation-classic');
+      }
 
       generationAwareElements.forEach((element) => {
-        const targetKey = isGenZ ? element.dataset.i18nGenz : element.dataset.i18nClassic;
+        const targetKey = isGenZ
+          ? element.dataset.i18nGenz || element.dataset.i18n
+          : element.dataset.i18nClassic || element.dataset.i18n;
         if (targetKey) {
           element.dataset.i18n = targetKey;
         }
       });
 
       if (heroCardImage) {
-        const config = heroCardMediaConfig[isGenZ ? GENERATION_GEN_Z : GENERATION_CLASSIC];
+        const configKey = isGenZ ? GENERATION_GEN_Z : GENERATION_CLASSIC;
+        const config = heroCardMediaConfig[configKey];
         if (config?.src && heroCardImage.getAttribute('src') !== config.src) {
           heroCardImage.setAttribute('src', config.src);
         }
@@ -485,17 +496,26 @@
 
       generationGroups.forEach((group) => {
         const mode = group.dataset.generationGroup;
+        if (showAllGenerations) {
+          group.hidden = false;
+          return;
+        }
+
         if (mode === GENERATION_GEN_Z) {
           group.hidden = !isGenZ;
         } else if (mode === GENERATION_CLASSIC) {
-          group.hidden = isGenZ;
+          group.hidden = currentGeneration !== GENERATION_CLASSIC;
         }
       });
     }
 
     function updateGenerationFromBirthYear(year) {
       const parsedYear = typeof year === 'number' ? year : parseBirthYear(year);
-      currentGeneration = determineGenerationFromBirthYear(parsedYear);
+      if (Number.isInteger(parsedYear)) {
+        currentGeneration = determineGenerationFromBirthYear(parsedYear);
+      } else {
+        currentGeneration = GENERATION_ALL;
+      }
       applyGenerationMode();
       applyTranslations(currentLanguage);
     }
@@ -506,9 +526,12 @@
     let selectedBirthYear = null;
     let ageGateInitialized = false;
     let agePickerScrollTimeout;
-    let currentGeneration = determineGenerationFromBirthYear(
-      parseBirthYear(localStorage.getItem(AGE_GATE_BIRTH_YEAR_KEY))
-    );
+    const storedAgeGateStatus = localStorage.getItem(AGE_GATE_STORAGE_KEY);
+    const storedBirthYear = parseBirthYear(localStorage.getItem(AGE_GATE_BIRTH_YEAR_KEY));
+    let currentGeneration =
+      storedAgeGateStatus === AGE_GATE_STATUS_DISMISSED || storedBirthYear === null
+        ? GENERATION_ALL
+        : determineGenerationFromBirthYear(storedBirthYear);
 
     const LANGUAGE_STORAGE_KEY = 'kinhdoLanguage';
     const savedLanguage = localStorage.getItem(LANGUAGE_STORAGE_KEY);
@@ -804,7 +827,7 @@
         return;
       }
 
-      localStorage.setItem(AGE_GATE_STORAGE_KEY, 'verified');
+      localStorage.setItem(AGE_GATE_STORAGE_KEY, AGE_GATE_STATUS_VERIFIED);
       localStorage.setItem(AGE_GATE_BIRTH_YEAR_KEY, String(selectedBirthYear));
       updateGenerationFromBirthYear(selectedBirthYear);
       setAgeGateMessage(null);
@@ -812,7 +835,11 @@
     };
 
     const dismissAgeGate = () => {
-      localStorage.setItem(AGE_GATE_STORAGE_KEY, 'dismissed');
+      localStorage.setItem(AGE_GATE_STORAGE_KEY, AGE_GATE_STATUS_DISMISSED);
+      localStorage.removeItem(AGE_GATE_BIRTH_YEAR_KEY);
+      currentGeneration = GENERATION_ALL;
+      applyGenerationMode();
+      applyTranslations(currentLanguage);
       setAgeGateMessage(null);
       hideAgeGate();
     };
@@ -956,7 +983,7 @@
       });
 
       const status = localStorage.getItem(AGE_GATE_STORAGE_KEY);
-      if (status === 'verified' || status === 'dismissed') {
+      if (status === AGE_GATE_STATUS_VERIFIED || status === AGE_GATE_STATUS_DISMISSED) {
         hideAgeGate(true);
       } else {
         showAgeGate(true);

--- a/products.html
+++ b/products.html
@@ -488,9 +488,12 @@
     const AGE_GATE_YEAR_START = 1945;
     const AGE_GATE_YEAR_END = 2025;
     const AGE_GATE_FILLER_COUNT = 2;
+    const AGE_GATE_STATUS_VERIFIED = 'verified';
+    const AGE_GATE_STATUS_DISMISSED = 'dismissed';
     const GEN_Z_YEAR_THRESHOLD = 1997;
     const GENERATION_CLASSIC = 'classic';
     const GENERATION_GEN_Z = 'genZ';
+    const GENERATION_ALL = 'all';
 
     const translatableElements = document.querySelectorAll('[data-i18n]');
     const languageToggle = document.getElementById('language-toggle');
@@ -527,20 +530,28 @@
     }
 
     function applyGenerationMode() {
+      const showAllGenerations = currentGeneration === GENERATION_ALL;
       const isGenZ = currentGeneration === GENERATION_GEN_Z;
 
-      document.body.classList.toggle('generation-genz', isGenZ);
-      document.body.classList.toggle('generation-classic', !isGenZ);
+      document.body.classList.remove('generation-genz', 'generation-classic');
+      if (isGenZ) {
+        document.body.classList.add('generation-genz');
+      } else if (currentGeneration === GENERATION_CLASSIC) {
+        document.body.classList.add('generation-classic');
+      }
 
       generationAwareElements.forEach((element) => {
-        const targetKey = isGenZ ? element.dataset.i18nGenz : element.dataset.i18nClassic;
+        const targetKey = isGenZ
+          ? element.dataset.i18nGenz || element.dataset.i18n
+          : element.dataset.i18nClassic || element.dataset.i18n;
         if (targetKey) {
           element.dataset.i18n = targetKey;
         }
       });
 
       if (heroCardImage) {
-        const config = heroCardMediaConfig[isGenZ ? GENERATION_GEN_Z : GENERATION_CLASSIC];
+        const configKey = isGenZ ? GENERATION_GEN_Z : GENERATION_CLASSIC;
+        const config = heroCardMediaConfig[configKey];
         if (config?.src && heroCardImage.getAttribute('src') !== config.src) {
           heroCardImage.setAttribute('src', config.src);
         }
@@ -554,17 +565,26 @@
 
       generationGroups.forEach((group) => {
         const mode = group.dataset.generationGroup;
+        if (showAllGenerations) {
+          group.hidden = false;
+          return;
+        }
+
         if (mode === GENERATION_GEN_Z) {
           group.hidden = !isGenZ;
         } else if (mode === GENERATION_CLASSIC) {
-          group.hidden = isGenZ;
+          group.hidden = currentGeneration !== GENERATION_CLASSIC;
         }
       });
     }
 
     function updateGenerationFromBirthYear(year) {
       const parsedYear = typeof year === 'number' ? year : parseBirthYear(year);
-      currentGeneration = determineGenerationFromBirthYear(parsedYear);
+      if (Number.isInteger(parsedYear)) {
+        currentGeneration = determineGenerationFromBirthYear(parsedYear);
+      } else {
+        currentGeneration = GENERATION_ALL;
+      }
       applyGenerationMode();
       applyTranslations(currentLanguage);
     }
@@ -575,9 +595,12 @@
     let selectedBirthYear = null;
     let ageGateInitialized = false;
     let agePickerScrollTimeout;
-    let currentGeneration = determineGenerationFromBirthYear(
-      parseBirthYear(localStorage.getItem(AGE_GATE_BIRTH_YEAR_KEY))
-    );
+    const storedAgeGateStatus = localStorage.getItem(AGE_GATE_STORAGE_KEY);
+    const storedBirthYear = parseBirthYear(localStorage.getItem(AGE_GATE_BIRTH_YEAR_KEY));
+    let currentGeneration =
+      storedAgeGateStatus === AGE_GATE_STATUS_DISMISSED || storedBirthYear === null
+        ? GENERATION_ALL
+        : determineGenerationFromBirthYear(storedBirthYear);
 
     const LANGUAGE_STORAGE_KEY = 'kinhdoLanguage';
     const savedLanguage = localStorage.getItem(LANGUAGE_STORAGE_KEY);
@@ -873,7 +896,7 @@
         return;
       }
 
-      localStorage.setItem(AGE_GATE_STORAGE_KEY, 'verified');
+      localStorage.setItem(AGE_GATE_STORAGE_KEY, AGE_GATE_STATUS_VERIFIED);
       localStorage.setItem(AGE_GATE_BIRTH_YEAR_KEY, String(selectedBirthYear));
       updateGenerationFromBirthYear(selectedBirthYear);
       setAgeGateMessage(null);
@@ -881,7 +904,11 @@
     };
 
     const dismissAgeGate = () => {
-      localStorage.setItem(AGE_GATE_STORAGE_KEY, 'dismissed');
+      localStorage.setItem(AGE_GATE_STORAGE_KEY, AGE_GATE_STATUS_DISMISSED);
+      localStorage.removeItem(AGE_GATE_BIRTH_YEAR_KEY);
+      currentGeneration = GENERATION_ALL;
+      applyGenerationMode();
+      applyTranslations(currentLanguage);
       setAgeGateMessage(null);
       hideAgeGate();
     };
@@ -1025,7 +1052,7 @@
       });
 
       const status = localStorage.getItem(AGE_GATE_STORAGE_KEY);
-      if (status === 'verified' || status === 'dismissed') {
+      if (status === AGE_GATE_STATUS_VERIFIED || status === AGE_GATE_STATUS_DISMISSED) {
         hideAgeGate(true);
       } else {
         showAgeGate(true);

--- a/styles.css
+++ b/styles.css
@@ -699,18 +699,18 @@
         background-size: contain;
         background-position: top center;
         background-repeat: no-repeat;
-        min-height: 220vw;
+        min-height: clamp(32rem, 120vw, 60rem);
       }
 
       .feature-announcement__content {
         justify-content: flex-end;
-        padding-top: clamp(14rem, 42vw, 24rem);
-        padding-bottom: clamp(2.5rem, 12vw, 5rem);
+        padding-top: clamp(7rem, 24vw, 12rem);
+        padding-bottom: clamp(2rem, 8vw, 4rem);
       }
 
       .feature-announcement__text {
         padding: 0 clamp(1rem, 6vw, 2rem);
-        margin-top: clamp(5rem, 20vw, 10rem);
+        margin-top: clamp(1.5rem, 6vw, 3rem);
       }
     }
 


### PR DESCRIPTION
## Summary
- tighten the mobile spacing around the feature announcement to reduce the empty gap before the next section
- treat a dismissed or unknown age gate as an "all" state so both generation product grids render by default
- clear any stored birth year when the age gate is dismissed to keep the behaviour consistent across pages

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68cda22cc3f083228460d63d54df95c2