### PR TITLE
Increase announcement text shadow depth

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -681,7 +681,9 @@
       color: #fff;
       text-shadow:
         0 2px 6px rgba(0, 0, 0, 0.5),
-        0 8px 24px rgba(0, 0, 0, 0.55);
+        0 8px 24px rgba(0, 0, 0, 0.55),
+        0 16px 48px rgba(0, 0, 0, 0.65),
+        0 24px 70px rgba(0, 0, 0, 0.7);
     }
 
     .feature-announcement__description {
@@ -691,7 +693,9 @@
       font-style: italic;
       text-shadow:
         0 2px 6px rgba(0, 0, 0, 0.45),
-        0 10px 28px rgba(0, 0, 0, 0.6);
+        0 10px 28px rgba(0, 0, 0, 0.6),
+        0 18px 54px rgba(0, 0, 0, 0.68),
+        0 28px 90px rgba(0, 0, 0, 0.75);
     }
 
     @media (max-width: 768px) {


### PR DESCRIPTION
## Summary
- intensify the drop shadows on the feature announcement heading and description for greater visual depth against the background artwork

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cda843aba88322b23381ecaa72b018